### PR TITLE
Modified Sender Buffer as per Pending Queue with Unit Tests

### DIFF
--- a/senderBuff_test.go
+++ b/senderBuff_test.go
@@ -1,0 +1,58 @@
+package sctp
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"testing"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func makePaths() []*Association{
+	paths := make([]*Association,5)
+	for i:= 0; i < 5; i ++{
+		addr := net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 9000+i,
+		}
+
+		conn, err := net.ListenUDP("udp", &addr)
+		if err != nil {
+			log.Panic(err)
+		}
+		defer conn.Close()
+	
+		config := Config{
+			NetConn:       conn,
+			LoggerFactory: logging.NewDefaultLoggerFactory(),
+		}
+		paths[i] = createAssociation(config)
+	}
+	return paths
+}
+
+func TestSenderBufferCreation(t *testing.T){
+	t.Run("Creating buffer", func (t *testing.T)  {
+		paths := makePaths()
+		senderBuff := newSenderBuffer(paths)
+		fmt.Print(senderBuff)
+		assert.NotNil(t,senderBuff,"should not be nil")
+	})
+}
+
+
+func TestSenderBufferPushPop(t *testing.T){
+	t.Run("Push and Pop",func (t *testing.T)  {
+		paths := makePaths()
+		senderBuff := newSenderBuffer(paths)
+		senderBuff.bufferSize = 30000
+		senderBuff.push(makeDataChunk(0, false, noFragment))
+		senderBuff.push(makeDataChunk(1, false, noFragment))
+		senderBuff.push(makeDataChunk(2, false, noFragment))
+		fmt.Print(senderBuff)
+		fmt.Print(senderBuff.pop(0))
+		fmt.Print(senderBuff)
+	})
+}

--- a/senderBuffer.go
+++ b/senderBuffer.go
@@ -13,9 +13,6 @@ func newSenderBuffer(paths []*Association) *senderBuffer {
 	senderBuff := senderBuffer{buffer: []*chunkPayloadData{}, paths: paths, splits: [][]*chunkPayloadData{}}
 	senderBuff.bufferSize = uint32(len(senderBuff.buffer))
 	a := make([][]*chunkPayloadData, len(paths))
-	for i := range a {
-		a[i] = make([]*chunkPayloadData, 0)
-	}
 	senderBuff.bufferedAmount = make([]uint32, len(paths))
 	senderBuff.bufferedAmountOutstandingBytes = make([]uint32, len(paths))
 	senderBuff.splits = a

--- a/senderBuffer.go
+++ b/senderBuffer.go
@@ -1,10 +1,61 @@
 package sctp
 
 type senderBuffer struct {
-	buffer                         [][]byte       // Main sender buffer needed
-	splits                         [][][]byte     // splits for buffer for each path
-	paths                          []*Association // Individual paths - can access MTU of each path from paths.mtu
-	bufferedAmount                 []uint32       // bufferredAmount[i] is the buffer size occupied by chunks on paths[i]
-	bufferedAmountOutstandingBytes []uint32       // bufferedAmountOutstandingBytes[i] is the buffer size occupied by outstanding chunks on paths[i]
-	bufferSize                     uint32         // total buffer size
+	buffer                         []*chunkPayloadData   // Main sender buffer needed
+	splits                         [][]*chunkPayloadData // splits for buffer for each path
+	paths                          []*Association        // Individual paths - can access MTU of each path from paths.mtu
+	bufferedAmount                 []uint32              // bufferredAmount[i] is the buffer size occupied by chunks on paths[i]
+	bufferedAmountOutstandingBytes []uint32              // bufferedAmountOutstandingBytes[i] is the buffer size occupied by outstanding chunks on paths[i]
+	bufferSize                     uint32                // total buffer size
+}
+
+func newSenderBuffer(paths []*Association) *senderBuffer {
+	senderBuff := senderBuffer{buffer: []*chunkPayloadData{}, paths: paths, splits: [][]*chunkPayloadData{}}
+	senderBuff.bufferSize = uint32(len(senderBuff.buffer))
+	a := make([][]*chunkPayloadData, len(paths))
+	for i := range a {
+		a[i] = make([]*chunkPayloadData, 0)
+	}
+	senderBuff.bufferedAmount = make([]uint32, len(paths))
+	senderBuff.bufferedAmountOutstandingBytes = make([]uint32, len(paths))
+	senderBuff.splits = a
+	return &senderBuff
+}
+
+func getPathIdx(q *senderBuffer, path *Association) int {
+	for i := range q.paths {
+		if q.paths[i].name == path.name {
+			return i
+		}
+	}
+	return -1
+}
+
+func (q *senderBuffer) push(c *chunkPayloadData) {
+	for pathIdx := range q.paths {
+		if sendCond_bufferedBytes_pathIdx(q, pathIdx) {
+			q.splits[pathIdx] = append(q.splits[pathIdx], c)
+			return
+		}
+	}
+}
+
+func (q *senderBuffer) pop(pathIdx int) *chunkPayloadData {
+	if len(q.splits[pathIdx]) == 0 {
+		return nil
+	}
+	data := q.splits[pathIdx][0]
+	q.splits[pathIdx] = q.splits[pathIdx][1:]
+	return data
+}
+
+func (q *senderBuffer) get(pathIdx int, pos int) *chunkPayloadData {
+	if len(q.splits[pathIdx]) == 0 || pos < 0 || pos >= len(q.splits[pathIdx]) {
+		return nil
+	}
+	return q.splits[pathIdx][pos]
+}
+
+func (q *senderBuffer) size(pathIdx int) int {
+	return len(q.splits[pathIdx])
 }

--- a/senderBufferSplitting.go
+++ b/senderBufferSplitting.go
@@ -4,7 +4,7 @@ func bufferSplitting(senderBuff senderBuffer) senderBuffer {
 
 	tempBuff := senderBuff.buffer
 	splitSize := uint(int(senderBuff.bufferSize) / len(senderBuff.paths))
-	var senderSplits [][][]byte
+	var senderSplits [][]*chunkPayloadData
 	for (len(tempBuff) > 0) && (uint(len(tempBuff)) >= splitSize) {
 		senderSplits = append(senderSplits, senderBuff.buffer[0:splitSize])
 		tempBuff = tempBuff[splitSize:]
@@ -22,7 +22,7 @@ func bufferSplitting(senderBuff senderBuffer) senderBuffer {
 	return senderBuff
 }
 
-func sendCond_bufferedBytes(senderBuff senderBuffer, path *Association) bool {
+func sendCond_bufferedBytes(senderBuff *senderBuffer, path *Association) bool {
 
 	var pathIdx int
 	for i := range senderBuff.paths {
@@ -31,6 +31,11 @@ func sendCond_bufferedBytes(senderBuff senderBuffer, path *Association) bool {
 			break
 		}
 	}
+	return senderBuff.bufferedAmount[pathIdx]+senderBuff.paths[pathIdx].mtu <= uint32(int(senderBuff.bufferSize)/len(senderBuff.paths))
+}
+
+func sendCond_bufferedBytes_pathIdx(senderBuff *senderBuffer, pathIdx int) bool {
+
 	return senderBuff.bufferedAmount[pathIdx]+senderBuff.paths[pathIdx].mtu <= uint32(int(senderBuff.bufferSize)/len(senderBuff.paths))
 }
 


### PR DESCRIPTION
Following changes were made

1. Sender Buffer Modified as per pending queue structure
2. Added Functions to interact with sender buffer
3. Modified sending condition function which now accepts *senderBuffer type

Added Testing functions for testing of sender buffer (in file senderBuff_test.go) for following
1. create
2. push
3. pop

Test 1 -> Objective: Creation of sender buffer -- Results (PASS)
<img width="711" alt="image" src="https://user-images.githubusercontent.com/56188720/184368243-ea37abda-72c0-4ae2-b3ad-d19add8a6236.png">

Test 2 -> Objective: Push and Pop to/from buffer -- Results (PASS)
<img width="704" alt="image" src="https://user-images.githubusercontent.com/56188720/184368471-3b8ca1dc-9075-48e5-bd22-156eb38ab41f.png">
